### PR TITLE
Bugfixes and compatibility with new compiler

### DIFF
--- a/CHANGES.TXT
+++ b/CHANGES.TXT
@@ -1,6 +1,11 @@
 Revision History
 ================
 
+2.2.1 (September 13, 2021)
+- Fixed `Character`.`TweenZ` not applying the correct value
+- 3.5.0: Fixed `Viewport`.`TweenX/Y` incorrectly clamping values
+- Changed the float `Elapsed++` which is not allowed on new compiler
+
 2.2.0 (September 8, 2020)
 - Fixed `Region` `StopTweenTint` result parameter (was not used)
 - Fixed `Region` tween tint saturation to 1-100 and luminance clamping to 0-100

--- a/Tween/Tween.asc
+++ b/Tween/Tween.asc
@@ -1252,7 +1252,7 @@ bool _TweenObject::Update() {
 
   if (this.Elapsed < 0.0) {
     // Handle delays.
-    this.Elapsed++;
+    this.Elapsed = this.Elapsed + 1.0;
   }
   else {
     // Compute the amount based on the easingType
@@ -1260,7 +1260,7 @@ bool _TweenObject::Update() {
 
     // Step
     this.Step(_t);
-    this.Elapsed++;
+    this.Elapsed = this.Elapsed + 1.0;
 
     // Repeat if needed or Release
     if (this.Elapsed > this.Duration) {
@@ -1460,7 +1460,7 @@ bool Tween::Update() {
   if (this.Duration > 0.0) {
     if (this.Elapsed < 0.0) {
       // Handle delays.
-      this.Elapsed++;
+      this.Elapsed = this.Elapsed + 1.0;
     }
     else {
       // Compute the amount based on the easingType
@@ -1478,7 +1478,7 @@ bool Tween::Update() {
         this.Value = TweenMaths.Lerp(this.FromValue, this.ToValue, t);
       }
 
-      this.Elapsed++;
+      this.Elapsed = this.Elapsed + 1.0;
 
       // Repeat tween if needed
       if (this.Elapsed > this.Duration) {

--- a/Tween/Tween.asc
+++ b/Tween/Tween.asc
@@ -1788,7 +1788,7 @@ int TweenY(this Character*, float timing, int toY, TweenEasingType easingType, T
   return _StartCharacterTween(_eTweenCharacterPosition, timing, 0, toY, 0, this.y, this, easingType, style, startDelay, timingType);
 }
 int TweenZ(this Character*, float timing, int toZ, TweenEasingType easingType, TweenStyle style, float startDelay, TweenTimingType timingType) {
-  return _StartCharacterTween(_eTweenCharacterZ, timing, 0, toZ, 0, this.z, this, easingType, style, startDelay, timingType);
+  return _StartCharacterTween(_eTweenCharacterZ, timing, toZ, 0, this.z, 0, this, easingType, style, startDelay, timingType);
 }
 int TweenX(this GUIControl*, float timing, int toX, TweenEasingType easingType, TweenStyle style, float startDelay, TweenTimingType timingType) {
   return _StartGUIControlTween(_eTweenGUIControlPosition, timing, toX, 0, this.X, 0, this, easingType, style, startDelay, timingType);

--- a/Tween/Tween.asc
+++ b/Tween/Tween.asc
@@ -1633,11 +1633,9 @@ int _StartScreenViewportTween(Viewport* viewport, _TweenType type, float timing,
 }
 
 int TweenX(this Viewport*, float timing, int toX, TweenEasingType easingType, TweenStyle style, float startDelay, TweenTimingType timingType) {
-  toX = TweenMaths.ClampInt(toX, 1, Screen.Width);
   return _StartScreenViewportTween(this, _eTweenViewportPosition, timing, toX, this.Y, this.X, this.Y, easingType, style, startDelay, timingType);
 }
 int TweenY(this Viewport*, float timing, int toY, TweenEasingType easingType, TweenStyle style, float startDelay, TweenTimingType timingType) {
-  toY = TweenMaths.ClampInt(toY, 1, Screen.Height);
   return _StartScreenViewportTween(this, _eTweenViewportPosition, timing, this.X, toY, this.X, this.Y, easingType, style, startDelay, timingType);
 }
 int TweenWidth(this Viewport*, float timing, int toWidth, TweenEasingType easingType, TweenStyle style, float startDelay, TweenTimingType timingType) {


### PR DESCRIPTION
## What changes did you make and why?
- Fixed `Character`.`TweenZ` not applying the correct value, the wrong function argument was being used (closes #15) 
- 3.5.0: Fixed `Viewport`.`TweenX/Y` incorrectly clamping values with the new camera system (only for API_V350)
- Changed the float `this.Elapsed++` to `this.Elapsed  = this.Elapsed + 1.0` for compatibility with new compiler

## How did you test it?
I'm actively using this modified version with the AGS4 branch.

## Did you complete the checklist?

- [ ] If new engine features are used, they are wrapped around `#ifver`
- [x] I updated `CHANGES.TXT`
- [ ] I updated the documentation
